### PR TITLE
[cat_stroll]新規登録フリガナのバリテーション設定、検索機能アップデート

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -14,9 +14,19 @@ class Public::PostsController < ApplicationController
 
   def index
     @posts = Post.all
-    # タグ検索機能・・・タグがある投稿を探す
+    # 検索機能
     if user_signed_in?
-      @posts = @posts.joins(:tags).distinct.where('tags.name like ?', "%#{params[:search]}%" ) if params[:search].present?
+      if params[:search].present?
+        # 投稿のタグから探す
+        tag_posts = @posts.joins(:tags).distinct.where('tags.name like ?', "%#{params[:search]}%")
+        # 投稿者を探す
+        posts = @posts.joins(:user).where('posts.name like ?', "%#{params[:search]}%").or(
+                @posts.joins(:user).where('users.first_name like ?', "%#{params[:search]}%")).or(
+                @posts.joins(:user).where('users.last_name like ?', "%#{params[:search]}%")).or(
+                @posts.joins(:user).where('users.user_name like ?', "%#{params[:search]}%"))
+        # tag_posts と posts で重複しないように uniq を設定
+        @posts = (tag_posts + posts).uniq
+      end
     else
       render :index
     end  

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,37 +16,43 @@ class Post < ApplicationRecord
   after_initialize :append_tags, unless: :new_record?
 
   def split_text
-    data = self.introduction.split("#")     #新規投稿でのデータで、タグを表す # のもつデータを配列で、投稿文と分ける
-    self.introduction = data.shift.chomp
-    self.current_tags = data                #タグをcurrent_tagsへ
+    unless self.introduction == ""
+      data = self.introduction.split("#")     #新規投稿でのデータで、タグを表す # のもつデータを配列で、投稿文と分ける
+      self.introduction = data.shift.chomp
+      self.current_tags = data                #タグをcurrent_tagsへ
+    end  
   end
 
   # タグの保存
   def save_tags
-    posted_tags = self.current_tags.map{|tag| Tag.find_or_create_by(name: tag) }      #新規投稿時のタグが新しいものか既にあるものかを判別する
-    recorded_tags = self.tags                           #新規投稿時に判別されたタグ
-    new_tags = posted_tags - recorded_tags              #26と27行目で新しいタグかを判別
-    old_tags = recorded_tags - posted_tags              #26と27行目で既にあるタグかを判別
-    # 新しいタグの場合
-    new_tags.each do |tag|
-      self.post_tags.create!(tag_id: tag.id)
-    end
-    # 既に保存されているタグの場合
-    old_tags.each do |tag|
-      count = tag.post_tags.size
-      if count <= 1
-        tag.destroy
-      else
-        post_tag = self.post_tags.find_by(tag_id: tag.id)
-        post_tag.destroy if post_tag
+    unless self.introduction == ""
+      posted_tags = self.current_tags.map{|tag| Tag.find_or_create_by(name: tag) }      #新規投稿時のタグが新しいものか既にあるものかを判別する
+      recorded_tags = self.tags                           #新規投稿時に判別されたタグ
+      new_tags = posted_tags - recorded_tags              #26と27行目で新しいタグかを判別
+      old_tags = recorded_tags - posted_tags              #26と27行目で既にあるタグかを判別
+      # 新しいタグの場合
+      new_tags.each do |tag|
+        self.post_tags.create!(tag_id: tag.id)
       end
+      # 既に保存されているタグの場合
+      old_tags.each do |tag|
+        count = tag.post_tags.size
+        if count <= 1
+          tag.destroy
+        else
+          post_tag = self.post_tags.find_by(tag_id: tag.id)
+          post_tag.destroy if post_tag
+        end
+      end  
     end
   end
   
   # 編集する際にフォームにタグを表示させる
   def append_tags
-    recorded_tags = "\r\n#" + self.tags.pluck(:name).join(' #')
-    self.introduction = self.introduction + recorded_tags
+    unless self.introduction == ""
+      recorded_tags = "\r\n#" + self.tags.pluck(:name).join(' #')
+      self.introduction = self.introduction + recorded_tags
+    end  
   end
 
 # 既にブックマークしているかを検証します

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  
-  validates :first_name, :last_name, :first_name_kana, :last_name_kana, presence: true
+
+  validates :first_name, :last_name, presence: true
+  # フリガナには全角カタカナしか保存できないようにする
+  validates :first_name_kana, :last_name_kana, format: {with: /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/,message: "全角カタカナで入力して下さい"}
   
 # post
   has_many :posts, dependent: :destroy

--- a/app/views/public/posts/index.html.erb
+++ b/app/views/public/posts/index.html.erb
@@ -96,11 +96,14 @@
     <!--タグ検索-->
       <div class="ml-5 mb-2">
         <%= form_with url: posts_path, method: :get, local: true do |f| %>
-          <%= f.text_field :search, class: "form-control w-50 d-inline border border-dark", value: params[:search], id: "searchBox" %>
-          <%= f.submit 'search', class: "btn btn-primary d-inline" %>
-          <span id="clearSearch" class="ml-2 btn btn-secondary">クリア</span>
+          <div class="d-flex">
+            <%= f.text_field :search, class: "ml-4 mr-2 form-control w-50 border border-dark", value: params[:search], id: "searchBox" %>
+            <%= f.submit 'search', class: "btn btn-primary" %>
+            <span id="clearSearch" class="ml-2 btn btn-secondary">クリア</span>
+          </div>
         <% end %>
       </div>
+      
       <!--検索ボックスの中をクリアに-->
       <script>
         $('#clearSearch').on('click', (e) => {
@@ -109,7 +112,7 @@
         })
       </script>
       
-      <div class="border border-dark border-5 rounded" style="margin-left:40px; height:510px; overflow: scroll; overflow-x: hidden;">
+      <div class="border border-dark border-5 rounded text-center" style="margin-left:40px; height:510px; overflow: scroll; overflow-x: hidden;">
         <table class="table table-borderless">
           <thead>
             <tr class="table-secondary">

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -4,7 +4,7 @@
       <h3><strong>新規登録</strong></h3>
     </div>
 
-    <div class="col-md-8 mt-4" style="margin-left:200px;">
+    <div class="col-md-10 mt-4" style="margin-left:8%;">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= render "public/shared/error_messages", resource: resource %>
       <table class="table table-borderless">
@@ -15,7 +15,7 @@
               <div class="d-flex" style="margin-left:3%;">
                 (姓)<%= f.text_field :first_name %>
               </div>
-              <div class="d-flex" style="margin-left:5%;">
+              <div class="d-flex" style="margin-left:12%;">
                 (名)<%= f.text_field :last_name %>
               </div>
             </div>
@@ -28,7 +28,7 @@
               <div class="d-flex">
                 (セイ)<%= f.text_field :first_name_kana %>
               </div>
-              <div class="d-flex" style="margin-left:2%;">
+              <div class="d-flex" style="margin-left:10%;">
                 (メイ)<%= f.text_field :last_name_kana %>
               </div>
             </div>
@@ -37,7 +37,7 @@
         <tr>
           <td>メールアドレス</td>
           <td>
-            <%= f.email_field :email, autofocus: true, autocomplete: "email", style: "width:90%" %>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", style: "width:70%" %>
           </td>
         </tr>
         <tr>
@@ -50,9 +50,9 @@
         </tr>
       </table>
 
-        <div class="col-md-12 text-center">
-          <%= f.submit "新規登録", style: "width:20%", class: "btn btn-success" %>
-        </div>
+      <div class="col-md-12 text-center">
+        <%= f.submit "新規登録", style: "width:20%", class: "btn btn-success" %>
+      </div>
     <% end %>
     </div>
   </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,34 +10,30 @@ ja:
   #  新規登録でのエラー数
   errors:
     messages:
-      not_saved: "の未入力項目があります"
+      not_saved: "の入力項目に問題があります"
       
   # 新規登録でのエラー表示
   activerecord:
     attributes:
       user:
-        first_name: "姓が"
-        last_name: "名が"
-        first_name_kana: "セイが"
-        last_name_kana: "メイが"
-        email: "メールアドレスが"
-        password: "パスワードが"
+        first_name: ""
+        last_name: ""
+        first_name_kana: ""
+        last_name_kana: ""
+        email: ""
+        password: ""
         password_confirmation: "パスワードが"
     errors:
       models:
         user:
           attributes:
             first_name:
-              blank: "未入力です"
+              blank: "入力必須項目です"
             last_name:
-              blank: "未入力です"  
-            first_name_kana:
-              blank: "未入力です" 
-            last_name_kana:
-              blank: "未入力です" 
+              blank: "入力必須項目です"  
             email:  
-              blank: "未入力です" 
+              blank: "入力必須項目です" 
             password:
-              blank: "未入力です" 
+              blank: "入力必須項目です" 
             password_confirmation:
               confirmation: "一致していません" 

--- a/db/migrate/20230526091828_create_posts.rb
+++ b/db/migrate/20230526091828_create_posts.rb
@@ -6,7 +6,7 @@ class CreatePosts < ActiveRecord::Migration[6.1]
       t.string :address, null: false
       t.float :latitude, null: false
       t.float :longitude, null: false
-      t.text :introduction, null: false
+      t.text :introduction
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 2023_05_26_092140) do
     t.string "address", null: false
     t.float "latitude", null: false
     t.float "longitude", null: false
-    t.text "introduction", null: false
+    t.text "introduction"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
Issue7
・新規登録フリガナに全角カタカナのみのバリテーション設定に変更
・検索機能のアップデート（タグ検索のみ→投稿場所、投稿者の検索も可能に）