### PR TITLE
[cat_stroll]public側 ユーザーindexページにタブを設定

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,17 +13,3 @@
  *= require_tree .
  *= require_self
  */
- 
- *{
-  padding: 0px;
-  margin: 0px;
-  box-sizing: border-box;
-  color: #6c6b6b
-}
- 
- 
- header{
-   background-color: #DDFFFF;
-   font-family: Chalkduster, "Bradley Hand", Courier, "Segoe Print", sans-serif;
- }
- 

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -4,6 +4,8 @@ class Public::UsersController < ApplicationController
 # ユーザー一覧
   def index
     @users=User.where(is_deleted: false)
+    @following_users = current_user.following_user
+    @follower_users = current_user.follower_user
   end
 
 # ユーザー詳細
@@ -11,7 +13,7 @@ class Public::UsersController < ApplicationController
     @user=User.find(params[:id])
     @posts=@user.posts
   end
-  
+
 # 退会確認
   def unsubscribe
     @user=current_user

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,6 +17,8 @@ import "../stylesheets/application"
 import '@fortawesome/fontawesome-free/js/all'
 import '../stylesheets/style'
 
+import "script.js"
+
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()

--- a/app/javascript/script.js
+++ b/app/javascript/script.js
@@ -1,0 +1,19 @@
+
+// turbolinksの無効化
+$(document).on('turbolinks:load', function() {
+  $(function() {
+    // .tabがクリックされたときを指定
+    $('.tab').click(function(){
+      // 今ある.tab-activeを削除
+      $('.tab-active').removeClass('tab-active');
+      // クリックされた.tabに.tab-activeを追加
+      $(this).addClass('tab-active');
+      // 今ある.box-showを削除
+      $('.box-show').removeClass('box-show');
+      // indexに.tabのindex番号を代入
+      const index = $(this).index();
+      // .tabboxとindexの番号が同じ要素に.box-showを追加
+      $('.tabbox').eq(index).addClass('box-show');
+    });
+  });
+});

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,3 +1,31 @@
 @use '~bootstrap/scss/bootstrap';
 @use '~@fortawesome/fontawesome-free/scss/fontawesome';
+ 
+.tab {
+  width: 27%;
+  padding: 10px;
+  cursor: pointer;
+  border-left: solid 1px #CCC;
+  border: solid 1px #CCC;
+}
 
+/*タブがactiveのときのデザイン*/
+.tab-active {
+  color: #FFF;
+  background: #19b5d1;
+  transition: all 0.2s ease-in-out;
+}
+/*タブの中身、最初は非表示*/
+.tabbox {
+  display: none;
+  padding: 15px;
+}
+/*box-showクラスのものだけ表示*/
+.box-show {
+  display: block;
+}
+/*hover時のアクション*/
+.tab:hover{
+  box-shadow: 0 4px 7px 0 rgba(0, 0, 0, 0.5);
+  transform: translateY(-1px);
+}

--- a/app/views/public/users/_list.html.erb
+++ b/app/views/public/users/_list.html.erb
@@ -1,0 +1,23 @@
+<div class="row">
+    <div class="col-md-8 mt-3 border border-dark" style="margin-left:17%; height:500px; padding:10px; overflow: scroll; overflow-x: hidden;">  
+      <% users.each do |user| %>
+        <table class="table table-border table-sm">
+          <tr>
+            <td class="col-md-2">
+              <%= image_tag user.get_profile_image(70,70) %><!--プロフィール画像-->
+            </td>
+            <td class="col-md-4" style="font-size:20px;">
+              <% if user.user_name.present? %>
+                <%= user.user_name%><!--ユーザーネーム-->
+              <% else %>
+                <%= user.first_name %><%= user.last_name %>
+              <% end %>
+            </td>
+            <td class="col-md-2">
+              <%= link_to "詳細", user_path(user.id), style: "font-size:20px"  %><!--詳細ページへのリンク-->
+            </td>
+          </tr>
+        </table>
+      <% end %>
+    </div>
+  </div>

--- a/app/views/public/users/index.html.erb
+++ b/app/views/public/users/index.html.erb
@@ -7,29 +7,35 @@
     </div>
   </div>
   
-  <div class="row">
-    <div class="col-md-8 mt-3 border border-dark" style="margin-left:18%; height:500px; padding:10px; overflow: scroll; overflow-x: hidden;">  
-      <% @users.each do |user| %>
-        <table class="table table-border table-sm">
-          <tr>
-            <td class="col-md-2">
-              <%= image_tag user.get_profile_image(70,70) %><!--プロフィール画像-->
-            </td>
-            <td class="col-md-4" style="font-size:20px;">
-              <% if user.user_name.present? %>
-                <%= user.user_name%><!--ユーザーネーム-->
-              <% else %>
-                <%= user.first_name %><%= user.last_name %>
-              <% end %>
-            </td>
-            <td class="col-md-2">
-              <%= link_to "詳細", user_path(user.id), style: "font-size:20px"  %><!--詳細ページへのリンク-->
-            </td>
-          </tr>
-        </table>
-      <% end %>
+  <!--タブ部分-->
+  <div>
+    <div>
+      <ul class="tab-list list-unstyled d-flex text-center" style="margin-left:16%;">
+        <li class="tab tab-active">
+          ユーザー
+        </li>
+        <li class="tab">
+          フォロワー
+        </li>
+        <li class="tab">
+          フォロー中
+        </li>
+      </ul>
+      <!--タブで選択された要素部分-->
+      <div class="tabbox-contents">
+        <div class="tabbox box-show">
+          <%= render 'list', users: @users %>    
+        </div>
+        <div class="tabbox">
+          <%= render 'list', users: @follower_users %>
+        </div>
+        <div class="tabbox">
+          <%= render 'list', users: @following_users %>
+        </div>
+      </div>
     </div>
   </div>
+      
   
 </div>
 

--- a/app/views/public/users/my_page.html.erb
+++ b/app/views/public/users/my_page.html.erb
@@ -1,11 +1,11 @@
 <div class="container">
-  
+
   <div class="row mt-4">
     <div class="col-md-12 text-center">
       <h3><strong>マイページ</strong></h3>
     </div>
   </div>
-  
+
   <div class="row">
     <div class="col-md-10 mt-1" style="margin-left:10%;">
       <div class="d-flex">
@@ -44,7 +44,7 @@
       </table>
     </div>
   </div>
-  
+
   <div class="row">
     <div class="col-md-12 text-center mb-3">
        <!--投稿数-->
@@ -69,7 +69,7 @@
           </strong>
           <%= link_to "フォロワー",user_follower_path(@user) %>
         </div>
-      </div>  
+      </div>
     </div>
   </div>
 
@@ -113,7 +113,7 @@
       </div>
     </div>
   </div>
-  
+
   <div class="row">
     <div class="col-md-12 text-center">
       <div class="mt-3">


### PR DESCRIPTION
Issue8
・ユーザーindexページにタブを設定
・ユーザーの一覧、current_userのフォロワーとフォロー中のユーザー一覧の三つをタブで切り替えて閲覧できるように設定
　部分テンプレートを使用
・app/Javascript/script.jsにタブのJavascriptを追加
・app/stylesheet/application.sccにタブのCSSを追加
