### PR TITLE
[cat_strill]　タグ編集修正

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -53,7 +53,7 @@ class Post < ApplicationRecord
 
   # 編集する際にフォームにタグを表示させる
   def append_tags
-    unless self.introduction == ""
+    if self.introduction.present? && self.tags.present?
       recorded_tags = "\r\n#" + self.tags.pluck(:name).join(' #')
       self.introduction = self.introduction + recorded_tags
     end


### PR DESCRIPTION
投稿編集でタグがない場合に、＃が追加されてしまう
修正完了